### PR TITLE
Add sql on demand check

### DIFF
--- a/AzureSQLConnectivityChecker.ps1
+++ b/AzureSQLConnectivityChecker.ps1
@@ -634,7 +634,8 @@ try {
                     throw
                 }
             }
-        } else {
+        }
+        else {
             RunSqlDBConnectivityTests $resolvedAddress
         }
 

--- a/AzureSQLConnectivityChecker.ps1
+++ b/AzureSQLConnectivityChecker.ps1
@@ -173,6 +173,10 @@ function IsManagedInstance([String] $Server) {
     return [bool]((($Server.ToCharArray() | Where-Object { $_ -eq '.' } | Measure-Object).Count) -ge 4)
 }
 
+function IsSqlOnDemand([String] $Server) {
+    return [bool]$Server.Split('-')[1].Contains('ondemand')
+}
+
 function IsManagedInstancePublicEndpoint([String] $Server) {
     return [bool]((IsManagedInstance $Server) -and ($Server -match '.public.'))
 }
@@ -626,6 +630,8 @@ try {
                     throw
                 }
             }
+        } if(IsSqlOnDemand $Server) {
+            
         }
         else {
             RunSqlDBConnectivityTests $resolvedAddress

--- a/AzureSQLConnectivityChecker.ps1
+++ b/AzureSQLConnectivityChecker.ps1
@@ -442,7 +442,11 @@ function RunSqlDBConnectivityTests($resolvedAddress) {
         Write-Host ' Tested (redirect) connectivity' $redirectTests 'times and' $redirectSucceeded 'of them succeeded' -ForegroundColor Yellow
         if ($redirectTests -gt 0) {
             Write-Host ' Please note this was just some tests to check connectivity using the 11000-11999 port range, not your database' -ForegroundColor Yellow
-            Write-Host ' Some tests may even fail and not be a problem since ports tested here are static and SQL DB is a dynamic environment.' -ForegroundColor Yellow
+            if(IsSqlOnDemand $Server) {
+                Write-Host ' Some tests may even fail and not be a problem since ports tested here are static and SQL on-demand is a dynamic serverless environment.' -ForegroundColor Yellow
+            } else {
+                Write-Host ' Some tests may even fail and not be a problem since ports tested here are static and SQL DB is a dynamic environment.' -ForegroundColor Yellow
+            }
             if ($redirectSucceeded / $redirectTests -ge 0.5 ) {
                 Write-Host ' Based on the result it is likely the Redirect Policy will work from this machine' -ForegroundColor Green
             }

--- a/AzureSQLConnectivityChecker.ps1
+++ b/AzureSQLConnectivityChecker.ps1
@@ -28,7 +28,7 @@ $Password = ''  # Set the login password you wish to use, 'AzSQLConnCheckerPassw
 # Optional parameters (default values will be used if ommited)
 $SendAnonymousUsageData = $true  # Set as $true (default) or $false
 $RunAdvancedConnectivityPolicyTests = $true  # Set as $true (default) or $false#Set as $true (default) or $false, this will download library needed for running advanced connectivity policy tests
-$CollectNetworkTrace = $false  # Set as $true (default) or $false
+$CollectNetworkTrace = $true  # Set as $true (default) or $false
 #EncryptionProtocol = ''  # Supported values: 'Tls 1.0', 'Tls 1.1', 'Tls 1.2'; Without this parameter operating system will choose the best protocol to use
 
 # Parameter region when Invoke-Command -ScriptBlock is used

--- a/AzureSQLConnectivityChecker.ps1
+++ b/AzureSQLConnectivityChecker.ps1
@@ -383,8 +383,9 @@ function PrintAverageConnectionTime($addressList, $port) {
 
 function RunSqlDBConnectivityTests($resolvedAddress) {
 
-    if(IsSqlOnDemand $Server) {
+    if (IsSqlOnDemand $Server) {
         Write-Host 'Detected as SQL on-demand endpoint' -ForegroundColor Yellow
+    }
     else {
         Write-Host 'Detected as SQL DB/DW Server' -ForegroundColor Yellow
     }
@@ -445,9 +446,10 @@ function RunSqlDBConnectivityTests($resolvedAddress) {
         Write-Host ' Tested (redirect) connectivity' $redirectTests 'times and' $redirectSucceeded 'of them succeeded' -ForegroundColor Yellow
         if ($redirectTests -gt 0) {
             Write-Host ' Please note this was just some tests to check connectivity using the 11000-11999 port range, not your database' -ForegroundColor Yellow
-            if(IsSqlOnDemand $Server) {
+            if (IsSqlOnDemand $Server) {
                 Write-Host ' Some tests may even fail and not be a problem since ports tested here are static and SQL on-demand is a dynamic serverless environment.' -ForegroundColor Yellow
-            } else {
+            }
+            else {
                 Write-Host ' Some tests may even fail and not be a problem since ports tested here are static and SQL DB is a dynamic environment.' -ForegroundColor Yellow
             }
             if ($redirectSucceeded / $redirectTests -ge 0.5 ) {

--- a/AzureSQLConnectivityChecker.ps1
+++ b/AzureSQLConnectivityChecker.ps1
@@ -593,7 +593,7 @@ try {
             throw
         }
 
-        if (!$Server.EndsWith('.database.windows.net') -and !$Server.EndsWith('.database.cloudapi.de') -and !$Server.EndsWith('.database.chinacloudapi.cn')) {
+        if (!$Server.EndsWith('.database.windows.net') -and !$Server.EndsWith('.database.cloudapi.de') -and !$Server.EndsWith('.database.chinacloudapi.cn') -and !$Server.EndsWith('.sql.azuresynapse.net')) {
             $Server = $Server + '.database.windows.net'
         }
 

--- a/AzureSQLConnectivityChecker.ps1
+++ b/AzureSQLConnectivityChecker.ps1
@@ -28,7 +28,7 @@ $Password = ''  # Set the login password you wish to use, 'AzSQLConnCheckerPassw
 # Optional parameters (default values will be used if ommited)
 $SendAnonymousUsageData = $true  # Set as $true (default) or $false
 $RunAdvancedConnectivityPolicyTests = $true  # Set as $true (default) or $false#Set as $true (default) or $false, this will download library needed for running advanced connectivity policy tests
-$CollectNetworkTrace = $true  # Set as $true (default) or $false
+$CollectNetworkTrace = $false  # Set as $true (default) or $false
 #EncryptionProtocol = ''  # Supported values: 'Tls 1.0', 'Tls 1.1', 'Tls 1.2'; Without this parameter operating system will choose the best protocol to use
 
 # Parameter region when Invoke-Command -ScriptBlock is used
@@ -175,7 +175,7 @@ function IsManagedInstance([String] $Server) {
 }
 
 function IsSqlOnDemand([String] $Server) {
-    return [bool]$Server.Split('-')[1].Contains('ondemand')
+    return [bool]($Server -match '-ondemand.')
 }
 
 function IsManagedInstancePublicEndpoint([String] $Server) {

--- a/AzureSQLConnectivityChecker.ps1
+++ b/AzureSQLConnectivityChecker.ps1
@@ -381,7 +381,11 @@ function PrintAverageConnectionTime($addressList, $port) {
 }
 
 function RunSqlDBConnectivityTests($resolvedAddress) {
-    Write-Host 'Detected as SQL DB Server' -ForegroundColor Yellow
+    if(IsSqlOnDemand $Server) {
+        Write-Host 'Detected as SQL on-demand endpoint' -ForegroundColor Yellow
+    } else {
+        Write-Host 'Detected as SQL DB Server' -ForegroundColor Yellow
+    }
     $gateway = $SQLDBGateways | Where-Object { $_.Gateways -eq $resolvedAddress }
     if (!$gateway) {
         Write-Host ' ERROR:' $resolvedAddress 'is not a valid gateway address' -ForegroundColor Red
@@ -630,10 +634,7 @@ try {
                     throw
                 }
             }
-        } if(IsSqlOnDemand $Server) {
-            
-        }
-        else {
+        } else {
             RunSqlDBConnectivityTests $resolvedAddress
         }
 


### PR DESCRIPTION
Added a simple check for connection strings which relate to SQL on-demand.
Typical URIs:
<name_of_workspace>-ondemand.sql.azuresynapse.net
<name_of_workspace>-ondemand.database.windows.net
Where <name_of_workspace> has a limit: all lowercase letters, no space, no special chars

I tested script now and it's running fine.