### PR TITLE
Fix missing spaces in PrintDNSResults

### DIFF
--- a/ReducedSQLConnectivityChecker.ps1
+++ b/ReducedSQLConnectivityChecker.ps1
@@ -176,16 +176,16 @@ function PrintLocalNetworkConfiguration() {
 
 function PrintDNSResults($dnsResult, [string] $dnsSource) {
     if ($dnsResult) {
-        Write-Output $(' Found DNS record in' + $dnsSource + '(IP Address:' + $dnsResult.IPAddress + ')')
+        Write-Output $(' Found DNS record in ' + $dnsSource + '(IP Address:' + $dnsResult.IPAddress + ')')
     }
     else {
-        Write-Output $(' Could not find DNS record in' + $dnsSource)
+        Write-Output $(' Could not find DNS record in ' + $dnsSource)
     }
 }
 
 function ValidateDNS([String] $Server) {
     Try {
-        Write-Output $('Validating DNS record for' + $Server)
+        Write-Output $('Validating DNS record for ' + $Server)
 
         $DNSfromHosts = Resolve-DnsName -Name $Server -CacheOnly -ErrorAction SilentlyContinue
         PrintDNSResults $DNSfromHosts 'hosts file'


### PR DESCRIPTION
You are missing spaces in the PrintDNSResults function. When it runs, the validator will output 'inhosts', 'incache', 'inDNS, and 'inOpen' with no space after the word 'in'. You also need a space in the ValidateDNS function for the same issue, currently there is no space between the word 'for' and the DNS record.