### PR TITLE
Fix: issue related to managed identity authentication

### DIFF
--- a/AzureSQLConnectivityChecker.ps1
+++ b/AzureSQLConnectivityChecker.ps1
@@ -84,6 +84,9 @@ if ($null -ne $parameters) {
     if ($null -ne $parameters['DelayBetweenConnections']) {
         $DelayBetweenConnections = $parameters['DelayBetweenConnections']
     }
+    if ($null -ne $parameters['UserAssignedIdentityClientId']) {
+        $UserAssignedIdentityClientId = $parameters['UserAssignedIdentityClientId']
+    }
     if ($null -ne $parameters['TrustServerCertificate']) {
         $TrustServerCertificate = $parameters['TrustServerCertificate']
     }
@@ -1480,6 +1483,10 @@ try {
         if ($AuthenticationType -like "*Microsoft Entra*") {
             Write-Host ' Authentication library:' $AuthenticationLibrary -ForegroundColor Yellow
             TrackWarningAnonymously ('Authentication library:' + $AuthenticationLibrary)
+        }
+
+        if ($null -ne $UserAssignedIdentityClientId -and $UserAssignedIdentityClientId -ne '') {
+            Write-Host ' UserAssignedIdentityClientId:' $UserAssignedIdentityClientId -ForegroundColor Yellow
         }
 
         Write-Host ' Server:' $Server -ForegroundColor Yellow

--- a/TDSClient/TDSClient/AuthenticationProvider/AuthenticationProvider.cs
+++ b/TDSClient/TDSClient/AuthenticationProvider/AuthenticationProvider.cs
@@ -151,9 +151,9 @@ namespace TDSClient.AuthenticationProvider
         /// <returns></returns>
         private async Task<string> GetAccessTokenForMSIAuth()
         {
-            return IdentityClientId != null ?
-                await MSALHelper.GetSQLAccessTokenFromMSALUsingUserAssignedManagedIdentity(Authority, IdentityClientId) :
-                await MSALHelper.GetSQLAccessTokenFromMSALUsingSystemAssignedManagedIdentity(Authority);
+            return string.IsNullOrEmpty(IdentityClientId) ?
+                await MSALHelper.GetSQLAccessTokenFromMSALUsingSystemAssignedManagedIdentity(Resource) :
+                await MSALHelper.GetSQLAccessTokenFromMSALUsingUserAssignedManagedIdentity(Resource, IdentityClientId);
         }
     }
 }


### PR DESCRIPTION
When running connectivity check it raises error *Exception:Value cannot be null.*
It appears that "UserAssignedIdentityClientId" parameter is never passed to the script.